### PR TITLE
security: full DevSecOps hardening — fix 10 vulnerabilities across application, container, and CI/CD layers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+.git
+.github
+.venv
+venv
+__pycache__
+*.pyc
+.pytest_cache
+.mypy_cache
+.ruff_cache
+.env
+.env.*
+*.md
+!decompose/README.md
+CLAUDE.md
+.claude/
+scans/
+docs/
+*.design.md
+*.implementation.md
+decompose.png
+decompose swagger.png

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,38 +3,36 @@ name: "JCR Docker Build"
 on:
   workflow_dispatch:
 
-
-
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-
       - name: Checkout
-        uses: actions/checkout@v2
-      
+        uses: actions/checkout@v4
+
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      
+        uses: docker/setup-buildx-action@v3
+
       - name: Get current date
         id: getDate
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+        run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
 
       - name: Get semantic version from file
         id: getSemver
-        run: echo "::set-output name=semver::$(cat VERSION | tr -d ' \t\n\r' )"
+        run: echo "semver=$(cat VERSION | tr -d ' \t\n\r')" >> "$GITHUB_OUTPUT"
 
       - name: Login to JFrog JCR
         run: |
-          echo ${{ secrets.JCR_USERNAME }} | docker login ${{ secrets.JCR_URL }} --username ${{ secrets.JCR_USERNAME }} --password ${{ secrets.JCR_TOKEN }}
+          echo ${{ secrets.JCR_TOKEN }} | docker login ${{ secrets.JCR_URL }} \
+            --username ${{ secrets.JCR_USERNAME }} --password-stdin
 
       - name: Build and push Docker image
         run: |
           IMAGE_NAME=${{ secrets.JCR_URL }}/docker/decompose
-
-          # Build and push latest
           docker buildx create --use
-          docker buildx build --platform linux/amd64,linux/arm64 --push -t $IMAGE_NAME:latest -t $IMAGE_NAME:${{ steps.getSemver.outputs.semver }} .
+          docker buildx build --platform linux/amd64,linux/arm64 --push \
+            -t $IMAGE_NAME:latest \
+            -t $IMAGE_NAME:${{ steps.getSemver.outputs.semver }} .

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
 
       - name: Get current date
         id: getDate
@@ -25,14 +25,18 @@ jobs:
         run: echo "semver=$(cat VERSION | tr -d ' \t\n\r')" >> "$GITHUB_OUTPUT"
 
       - name: Login to JFrog JCR
-        run: |
-          echo ${{ secrets.JCR_TOKEN }} | docker login ${{ secrets.JCR_URL }} \
-            --username ${{ secrets.JCR_USERNAME }} --password-stdin
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ${{ secrets.JCR_URL }}
+          username: ${{ secrets.JCR_USERNAME }}
+          password: ${{ secrets.JCR_TOKEN }}
 
       - name: Build and push Docker image
-        run: |
-          IMAGE_NAME=${{ secrets.JCR_URL }}/docker/decompose
-          docker buildx create --use
-          docker buildx build --platform linux/amd64,linux/arm64 --push \
-            -t $IMAGE_NAME:latest \
-            -t $IMAGE_NAME:${{ steps.getSemver.outputs.semver }} .
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ secrets.JCR_URL }}/docker/decompose:latest
+            ${{ secrets.JCR_URL }}/docker/decompose:${{ steps.getSemver.outputs.semver }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,16 +9,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -32,7 +32,7 @@ jobs:
         run: echo "semver=$(cat VERSION | tr -d ' \t\n\r')" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,39 +4,35 @@ on:
   release:
     types: [ published ]
 
-
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v2
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      -
-        name: Login to DockerHub
-        uses: docker/login-action@v1 
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
+
       - name: Get current date
         id: getDate
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+        run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
 
       - name: Get semantic version from file
         id: getSemver
-        run: echo "::set-output name=semver::$(cat VERSION | tr -d ' \t\n\r' )"
+        run: echo "semver=$(cat VERSION | tr -d ' \t\n\r')" >> "$GITHUB_OUTPUT"
 
-      
-      -
-        name: Build and push
-        uses: docker/build-push-action@v2
+      - name: Build and push
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,30 @@
-
-FROM techblog/fastapi:latest
+FROM python:3.12-slim
 
 LABEL maintainer="tomer.klein@gmail.com"
-ENV PYTHONIOENCODING=utf-8
-ENV LANG=C.UTF-8
 
-RUN mkdir -p /opt/decompose
- 
-COPY decompose /opt/decompose
-WORKDIR /opt/decompose/ 
+ENV PYTHONIOENCODING=utf-8 \
+    LANG=C.UTF-8 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1
 
-RUN pip3 install -r requirements.txt
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/decompose
+
+COPY decompose/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY decompose/ .
+
+RUN useradd --create-home --uid 10001 appuser \
+    && chown -R appuser:appuser /opt/decompose
+USER appuser
 
 EXPOSE 8080
 
-ENTRYPOINT ["/usr/bin/python3", "decompose.py"]
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl -fsS http://127.0.0.1:8080/ || exit 1
+
+ENTRYPOINT ["python3", "decompose.py"]

--- a/decompose/decompose.py
+++ b/decompose/decompose.py
@@ -147,10 +147,7 @@ def get_containers(request: Request):
 @app.get("/api/generate")
 def generate_compose(request: Request, cname: str=""):
     data = main(cname)
-    with open('docker-compose.yaml', 'w') as outfile:
-        pyaml.dump(data, outfile)
-    with open ("docker-compose.yaml", "r") as composefile:
-        return composefile.read()
+    return pyaml.dump(data)
 
 @app.get("/api/download")
 def get_compose(request: Request, cname: str=""):

--- a/decompose/decompose.py
+++ b/decompose/decompose.py
@@ -125,24 +125,13 @@ def Convert(lst):
 
 
 
-app = FastAPI(title="DeCompose", description="Generate docker-compose from running containers", version="1.0.0")
 logger.info("Configuring app")
-app = FastAPI(title="DeCompose", description="Generate docker-compose from running containers", version="1.0.0")
+app = FastAPI(title="DeCompose", description="Generate docker-compose from running containers", version="1.0.0",
+              docs_url=None, redoc_url=None)
 app.mount("/dist", StaticFiles(directory="dist"), name="dist")
 app.mount("/js", StaticFiles(directory="dist/js"), name="js")
 app.mount("/css", StaticFiles(directory="dist/css"), name="css")
 templates = Jinja2Templates(directory="templates/")
-
-
-origins = ["*"]
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=origins,
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
 
 
 @app.get("/api/containers")

--- a/decompose/decompose.py
+++ b/decompose/decompose.py
@@ -1,18 +1,13 @@
-import os, json, requests, uvicorn, uuid, docker
-import shutil, aiofiles, sqlite3, base64
-import sys, argparse, pyaml
+import os, uvicorn, docker
+import pyaml
 from collections import OrderedDict
-from os import environ, path
 from loguru import logger
-from fastapi import FastAPI, Request, File, Form, UploadFile
-from fastapi.responses import UJSONResponse
+from fastapi import FastAPI, Request, HTTPException
 from fastapi.templating import Jinja2Templates
-from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import JSONResponse
 from starlette.responses import FileResponse
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.encoders import jsonable_encoder
 
 def main(cname):
     struct = {}
@@ -31,10 +26,9 @@ def generate(cname):
     c = docker.from_env()
 
     try:
-        cid = [x.short_id for x in c.containers.list(all=True) if cname == x.name or x.short_id in cname][0]
+        cid = [x.short_id for x in c.containers.list(all=True) if cname == x.name or cname == x.short_id][0]
     except IndexError:
-        print("That container is not available.")
-        sys.exit(1)
+        raise HTTPException(status_code=404, detail=f"Container '{cname}' not found")
 
     cattrs = c.containers.get(cid).attrs
 

--- a/decompose/decompose.py
+++ b/decompose/decompose.py
@@ -6,8 +6,8 @@ from fastapi import FastAPI, Request, HTTPException
 from fastapi.templating import Jinja2Templates
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import FileResponse
-from fastapi.middleware.cors import CORSMiddleware
 
 def main(cname):
     struct = {}
@@ -128,6 +128,23 @@ def Convert(lst):
 logger.info("Configuring app")
 app = FastAPI(title="DeCompose", description="Generate docker-compose from running containers", version="1.0.0",
               docs_url=None, redoc_url=None)
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        response = await call_next(request)
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        response.headers["Content-Security-Policy"] = (
+            "default-src 'self'; "
+            "script-src 'self' 'unsafe-inline'; "
+            "style-src 'self' 'unsafe-inline'; "
+            "img-src 'self' data:;"
+        )
+        return response
+
+app.add_middleware(SecurityHeadersMiddleware)
+
 app.mount("/dist", StaticFiles(directory="dist"), name="dist")
 app.mount("/js", StaticFiles(directory="dist/js"), name="js")
 app.mount("/css", StaticFiles(directory="dist/css"), name="css")

--- a/decompose/decompose.py
+++ b/decompose/decompose.py
@@ -165,10 +165,16 @@ def generate_compose(request: Request, cname: str=""):
 
 @app.get("/api/download")
 def get_compose(request: Request, cname: str=""):
+    import re, tempfile
+    if not re.fullmatch(r'[a-zA-Z0-9][a-zA-Z0-9_.\-]*', cname):
+        raise HTTPException(status_code=400, detail="Invalid container name")
     data = main(cname)
-    with open(cname +'-docker-compose.yaml', 'w') as outfile:
-        pyaml.dump(data, outfile)
-    return FileResponse(cname + '-docker-compose.yaml', media_type='application/octet-stream',filename=cname + '-docker-compose.yaml')
+    safe_name = os.path.basename(cname)
+    filename = f"{safe_name}-docker-compose.yaml"
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as tmp:
+        pyaml.dump(data, tmp)
+        tmp_path = tmp.name
+    return FileResponse(tmp_path, media_type='application/octet-stream', filename=filename)
 
 @app.get("/")
 def home(request: Request):

--- a/decompose/requirements.txt
+++ b/decompose/requirements.txt
@@ -1,4 +1,6 @@
-pyaml==20.4.0
-docker==4.4.4
-six==1.16.0
-requests>=2.32.2 # not directly required, pinned by Snyk to avoid a vulnerability
+fastapi==0.115.0
+uvicorn[standard]==0.30.6
+docker==7.1.0
+pyaml==24.4.0
+loguru==0.7.2
+requests>=2.32.2

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,8 +4,21 @@ services:
   decompose:
     image: techblog/decompose
     container_name: decompose
-    restart: always
+    restart: unless-stopped
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     ports:
-      - "8080:8080"   
+      - "8080:8080"
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8080/"]
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3


### PR DESCRIPTION
  ## Summary

  Full security audit and remediation of the DeCompose application.
  10 vulnerabilities fixed across 4 layers (application, dependencies,
  container, CI/CD), each in an isolated commit.

  ## Fixes

  | Commit | Severity | Finding | Fix |
  |--------|----------|---------|-----|
  | `2514e2d` | HIGH | `sys.exit(1)` in request handler terminates the uvicorn process on any unknown container name — unauthenticated one-request DoS | Raise `HTTPException(404)` instead; tighten container-matching
  from substring to exact equality |
  | `69b1dbf` | HIGH | Path traversal in `/api/download` — `cname` used directly as a filename; old substring match `x.short_id in cname` allowed `abc123/../../etc/backdoor` to bypass validation | Validate `cname`
  against Docker's allowed charset `[a-zA-Z0-9_.-]`; write output to `NamedTemporaryFile` |
  | `e4da7dd` | HIGH | CORS `allow_origins=["*"]` + `allow_credentials=True` causes Starlette to reflect the requesting `Origin` verbatim, allowing any cross-origin page to make credentialed requests and read full API
  responses including container secrets | Remove CORS middleware (app serves its own frontend from the same origin); disable public Swagger UI/ReDoc (`docs_url=None, redoc_url=None`) |
  | `20884a1` | MEDIUM | TOCTOU race on shared `docker-compose.yaml` — concurrent requests could read each other's output, leaking container secrets across callers; secret-containing files accumulated on disk
  indefinitely | Return `pyaml.dump(data)` string directly — no file I/O needed |
  | `0b603dd` | MEDIUM | No security response headers — missing `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Content-Security-Policy` | Add `SecurityHeadersMiddleware` setting all four headers on
  every response |
  | `c41144b` | HIGH | `docker==4.4.4` (4 years old) and `pyaml==20.4.0` (locks transitive PyYAML to pre-CVE-2020-14343 range); `fastapi`/`uvicorn`/`loguru` inherited unversioned from base image | Update to
  `docker==7.1.0`, `pyaml==24.4.0`; pin all runtime deps explicitly |
  | `aa22196` | HIGH | Dockerfile used `techblog/fastapi:latest` — unverified custom image on a mutable tag (supply-chain risk); container ran as root (uid 0) | Switch to `python:3.12-slim`; add `appuser` (uid 10001)
  with `USER` directive; add `HEALTHCHECK` |
  | `1a9adc9` | MEDIUM | No `.dockerignore` — full repo sent to Docker daemon as build context; `.env` files or credentials present at repo root would be silently embedded in published images | Add `.dockerignore`
  excluding `.git`, `.env*`, `CLAUDE.md`, `.claude/`, docs, screenshots |
  | `07d108e` | HIGH | Docker socket mounted read-write (app only needs read access); no capability drops; no `no-new-privileges`; no healthcheck — combined with running as root, any RCE in the app yields full host
  compromise via the socket | Add `:ro` to socket mount; `cap_drop: ALL`; `security_opt: [no-new-privileges:true]`; `read_only: true` with `/tmp` tmpfs; `healthcheck` |
  | `8158de0` | MEDIUM | GitHub Actions pinned to mutable tags (`@v3`, `@v4`) — supply-chain compromise could silently execute malicious code in CI; JCR login interpolated token directly into a shell command, exposing
  it in Actions debug logs | Pin all 5 actions to immutable commit SHAs; replace inline `docker login` shell with `docker/login-action` |

  ## Test plan

  - [ ] `GET /api/generate?cname=doesnotexist` returns HTTP 404, server stays up
  - [ ] `GET /api/download?cname=abc123/../../../etc/passwd` returns HTTP 400
  - [ ] Cross-origin credentialed `fetch` to `/api/containers` is rejected by the browser
  - [ ] `/docs` and `/redoc` return HTTP 404
  - [ ] Response headers include `X-Frame-Options: DENY` and `Content-Security-Policy`
  - [ ] Docker image builds successfully from `python:3.12-slim`
  - [ ] `docker exec decompose id` shows a non-root user (uid 10001)
  - [ ] Docker socket is mounted `:ro` and the container starts and passes healthcheck